### PR TITLE
Add range queries for aggregations

### DIFF
--- a/src/main/java/io/mewil/sturgeon/Configuration.java
+++ b/src/main/java/io/mewil/sturgeon/Configuration.java
@@ -10,27 +10,27 @@ import java.util.stream.Collectors;
 @Getter
 public class Configuration {
 
-    private static class LazyHolder {
-        private static final Configuration INSTANCE = new Configuration();
-    }
+  private static class LazyHolder {
+    private static final Configuration INSTANCE = new Configuration();
+  }
 
-    public static Configuration getInstance() {
-        return LazyHolder.INSTANCE;
-    }
+  public static Configuration getInstance() {
+    return LazyHolder.INSTANCE;
+  }
 
-    private static String getEnv(final String name, final String defaultValue) {
-        return System.getenv().getOrDefault(name, defaultValue);
-    }
+  private static String getEnv(final String name, final String defaultValue) {
+    return System.getenv().getOrDefault(name, defaultValue);
+  }
 
-    private static String getEnv(final String name) {
-        return getEnv(name, "");
-    }
+  private static String getEnv(final String name) {
+    return getEnv(name, "");
+  }
 
-    private final List<String> elasticsearchHosts = Arrays.stream(getEnv("ELASTICSEARCH_HOSTS").split(","))
-            .collect(Collectors.toList());
+  private final List<String> elasticsearchHosts =
+      Arrays.stream(getEnv("ELASTICSEARCH_HOSTS").split(",")).collect(Collectors.toList());
 
-    private final Pattern elasticsearchIndexIncludePattern = Pattern.compile(getEnv("ELASTICSEARCH_INDEX_INCLUDE_PATTERN", ".*"));
+  private final Pattern elasticsearchIndexIncludePattern =
+      Pattern.compile(getEnv("ELASTICSEARCH_INDEX_INCLUDE_PATTERN", ".*"));
 
-    private final Boolean enableAggregations = Boolean.getBoolean(getEnv("ENABLE_AGGREGATIONS", "true"));
-
+  private final Boolean enableAggregations = Boolean.valueOf(getEnv("ENABLE_AGGREGATIONS", "true"));
 }

--- a/src/main/java/io/mewil/sturgeon/ElasticsearchClient.java
+++ b/src/main/java/io/mewil/sturgeon/ElasticsearchClient.java
@@ -81,8 +81,10 @@ public final class ElasticsearchClient {
     }
 
     public SearchResponse queryWithAggregation(final String index, final List<String> selectedFields,
+                                               final List<QueryBuilder> queryBuilders,
                                                final AggregationType aggregationType) throws IOException {
         final SearchSourceBuilder sourceBuilder = new SearchSourceBuilder().size(0);
+        queryBuilders.forEach(sourceBuilder::query);
         selectedFields.forEach(field -> {
             switch (aggregationType) {
                 case AVG -> sourceBuilder.aggregation(AggregationBuilders.avg(field).field(field));

--- a/src/main/java/io/mewil/sturgeon/schema/GraphQLSchemaBuilder.java
+++ b/src/main/java/io/mewil/sturgeon/schema/GraphQLSchemaBuilder.java
@@ -30,11 +30,15 @@ public final class GraphQLSchemaBuilder {
     return buildSchemaFromIndexMappings(ElasticsearchClient.getInstance().getMappings());
   }
 
-  private static GraphQLSchema buildSchemaFromIndexMappings(final Map<String, Map<String, Object>> mappings) {
-    return new GraphQLSchema.Builder().query(new GraphQLObjectType.Builder()
-            .name("Query")
-            .fields(buildSchemasFromIndexMappings(mappings))
-            .build()).build();
+  private static GraphQLSchema buildSchemaFromIndexMappings(
+      final Map<String, Map<String, Object>> mappings) {
+    return new GraphQLSchema.Builder()
+        .query(
+            new GraphQLObjectType.Builder()
+                .name("Query")
+                .fields(buildSchemasFromIndexMappings(mappings))
+                .build())
+        .build();
   }
 
   private static List<GraphQLFieldDefinition> buildSchemasFromIndexMappings(
@@ -51,7 +55,8 @@ public final class GraphQLSchemaBuilder {
     final String normalizedIndexName =
         NameNormalizer.getInstance().getGraphQLName(indexMapping.getKey());
     final GraphQLObjectType documentType = new DocumentTypeBuilder(indexMapping).build();
-    final GraphQLArgument booleanQueryArguments = new BooleanQueryArgumentBuilder(indexMapping).build();
+    final GraphQLArgument booleanQueryArguments =
+        new BooleanQueryArgumentBuilder(indexMapping).build();
 
     final Stream<GraphQLFieldDefinition> schemas =
         Stream.of(
@@ -76,6 +81,7 @@ public final class GraphQLSchemaBuilder {
                 new GraphQLFieldDefinition.Builder()
                     .name(String.format("%s_aggregations", normalizedIndexName))
                     .type(new DocumentAggregationTypeBuilder(indexMapping).build())
+                    .argument(booleanQueryArguments)
                     .dataFetcher(environment -> environment.getSelectionSet().getFields())
                     .build()))
         : schemas;

--- a/src/main/java/io/mewil/sturgeon/schema/resolver/IndexDataFetcherBuilder.java
+++ b/src/main/java/io/mewil/sturgeon/schema/resolver/IndexDataFetcherBuilder.java
@@ -1,25 +1,19 @@
 package io.mewil.sturgeon.schema.resolver;
 
 import graphql.schema.DataFetcher;
-import graphql.schema.DataFetchingEnvironment;
 import io.mewil.sturgeon.ElasticsearchClient;
 import io.mewil.sturgeon.schema.SchemaConstants;
-import io.mewil.sturgeon.schema.types.BooleanQueryType;
-import io.mewil.sturgeon.schema.util.ElasticsearchDecoder;
-import io.mewil.sturgeon.schema.util.NameNormalizer;
 import io.mewil.sturgeon.schema.util.QueryFieldSelector;
 import io.mewil.sturgeon.schema.util.QueryFieldSelectorResult;
-import org.elasticsearch.index.query.BoolQueryBuilder;
-import org.elasticsearch.index.query.QueryBuilder;
-import org.elasticsearch.index.query.QueryBuilders;
-import org.elasticsearch.index.query.RangeQueryBuilder;
 import org.elasticsearch.search.SearchHits;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+
+import static io.mewil.sturgeon.schema.resolver.QueryAdapter.buildQueryFromArguments;
+import static io.mewil.sturgeon.schema.util.ElasticsearchDecoder.decodeElasticsearchDoc;
 
 public class IndexDataFetcherBuilder extends DataFetcherBuilder {
   public IndexDataFetcherBuilder(String index) {
@@ -32,52 +26,23 @@ public class IndexDataFetcherBuilder extends DataFetcherBuilder {
   public DataFetcher<List<Map<String, Object>>> build() {
     return dataFetchingEnvironment -> {
       final QueryFieldSelectorResult selectorResult =
-              QueryFieldSelector.getSelectedFieldsFromQuery(dataFetchingEnvironment);
+          QueryFieldSelector.getSelectedFieldsFromQuery(dataFetchingEnvironment);
       final int size = dataFetchingEnvironment.getArgument(SchemaConstants.SIZE);
-      final SearchHits hits = ElasticsearchClient.getInstance().query(index, size, selectorResult.getFields(), buildQueryFromArguments(dataFetchingEnvironment)).getHits();
+      final SearchHits hits =
+          ElasticsearchClient.getInstance()
+              .query(
+                  index,
+                  size,
+                  selectorResult.getFields(),
+                  buildQueryFromArguments(dataFetchingEnvironment.getArguments()))
+              .getHits();
 
       return Arrays.stream(hits.getHits())
-              .map(hit -> ElasticsearchDecoder.decodeElasticsearchDoc(hit.getSourceAsMap(), selectorResult.getIncludeId(), hit.getId()))
-              .collect(Collectors.toList());
+          .map(
+              hit ->
+                  decodeElasticsearchDoc(
+                      hit.getSourceAsMap(), selectorResult.getIncludeId(), hit.getId()))
+          .collect(Collectors.toList());
     };
-  }
-
-  public List<QueryBuilder> buildQueryFromArguments(final DataFetchingEnvironment dataFetchingEnvironment) {
-    final List<QueryBuilder> queryBuilders = new ArrayList<>();
-    dataFetchingEnvironment.getArguments().forEach((key, value) -> {
-      switch (key) {
-        case SchemaConstants.BOOLEAN_QUERY:
-          // TODO: Refactor unchecked cast
-          queryBuilders.add(buildBooleanQuery((Map<String, Object>) value));
-          break;
-      }
-    });
-    return queryBuilders;
-  }
-
-  private BoolQueryBuilder buildBooleanQuery(final Map<String, Object> booleanOccurrenceTypes) {
-    final BoolQueryBuilder boolQueryBuilder = QueryBuilders.boolQuery();
-    booleanOccurrenceTypes.forEach((key, value) -> {
-      // TODO: Refactor unchecked cast
-      Map<String, Object> map = ((Map<String, Object>) value);
-      switch (BooleanQueryType.valueOf(key.toUpperCase())) {
-        case FILTER:
-          map.entrySet().forEach(e -> boolQueryBuilder.filter(buildRangeQuery(e)));
-      }
-    });
-    return boolQueryBuilder;
-  }
-
-  private RangeQueryBuilder buildRangeQuery(final Map.Entry<String, Object> field) {
-    final RangeQueryBuilder rangeQueryBuilder = QueryBuilders.rangeQuery(NameNormalizer.getInstance().getOriginalName(field.getKey()));
-    ((Map<String, Object>) field.getValue()).forEach((key, value) -> {
-      switch (key) {
-        case "gt"  -> rangeQueryBuilder.gt(value);
-        case "gte" -> rangeQueryBuilder.gte(value);
-        case "lt" -> rangeQueryBuilder.lt(value);
-        case "lte" -> rangeQueryBuilder.lte(value);
-      }
-    });
-    return rangeQueryBuilder;
   }
 }

--- a/src/main/java/io/mewil/sturgeon/schema/resolver/QueryAdapter.java
+++ b/src/main/java/io/mewil/sturgeon/schema/resolver/QueryAdapter.java
@@ -1,0 +1,80 @@
+package io.mewil.sturgeon.schema.resolver;
+
+import io.mewil.sturgeon.schema.SchemaConstants;
+import io.mewil.sturgeon.schema.types.BooleanQueryType;
+import io.mewil.sturgeon.schema.util.NameNormalizer;
+import org.elasticsearch.index.query.BoolQueryBuilder;
+import org.elasticsearch.index.query.QueryBuilder;
+import org.elasticsearch.index.query.QueryBuilders;
+import org.elasticsearch.index.query.RangeQueryBuilder;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public final class QueryAdapter {
+
+    public static List<QueryBuilder> buildQueryFromArguments(final Map<String, Object> arguments) {
+        final List<QueryBuilder> queryBuilders = new ArrayList<>();
+        arguments.forEach((key, value) -> {
+            switch (key) {
+                case SchemaConstants.BOOLEAN_QUERY:
+                    // TODO: Refactor unchecked cast
+                    queryBuilders.add(buildBooleanQuery((Map<String, Object>) value));
+                    break;
+            }
+        });
+        return queryBuilders;
+    }
+
+    private  static BoolQueryBuilder buildBooleanQuery(final Map<String, Object> booleanOccurrenceTypes) {
+        final BoolQueryBuilder boolQueryBuilder = QueryBuilders.boolQuery();
+        booleanOccurrenceTypes.forEach((key, value) -> {
+            // TODO: Refactor unchecked cast
+            Set<Map.Entry<String, Object>> entrySet = ((Map<String, Object>) value).entrySet();
+            switch (BooleanQueryType.valueOf(key.toUpperCase())) {
+                case FILTER:
+                    entrySet.forEach(e -> buildTermLevelQueries(e).forEach(boolQueryBuilder::filter));
+                    break;
+                case SHOULD:
+                    entrySet.forEach(e -> buildTermLevelQueries(e).forEach(boolQueryBuilder::should));
+                    break;
+                case MUST:
+                    entrySet.forEach(e -> buildTermLevelQueries(e).forEach(boolQueryBuilder::must));
+                    break;
+                case MUST_NOT:
+                    entrySet.forEach(e -> buildTermLevelQueries(e).forEach(boolQueryBuilder::mustNot));
+                    break;
+            }
+        });
+        return boolQueryBuilder;
+    }
+
+    private static List<QueryBuilder> buildTermLevelQueries(final Map.Entry<String, Object> field) {
+        final String fieldName = field.getKey();
+        final Set<Map.Entry<String, Object>> termLevelQueries = ((Map<String, Object>) field.getValue()).entrySet();
+        final List<QueryBuilder> queryBuilders =  new ArrayList<>();
+
+        termLevelQueries.forEach(entry -> {
+            switch (entry.getKey()) {
+                case "range" -> queryBuilders.add(buildRangeQuery(fieldName, entry));
+            }
+        });
+
+        return queryBuilders;
+    }
+
+    private static RangeQueryBuilder buildRangeQuery(final String fieldName, final Map.Entry<String, Object> field) {
+        final RangeQueryBuilder rangeQueryBuilder = QueryBuilders.rangeQuery(NameNormalizer.getInstance().getOriginalName(fieldName));
+        ((Map<String, Object>) field.getValue()).forEach((key, value) -> {
+            switch (key) {
+                case "gt"  -> rangeQueryBuilder.gt(value);
+                case "gte" -> rangeQueryBuilder.gte(value);
+                case "lt" -> rangeQueryBuilder.lt(value);
+                case "lte" -> rangeQueryBuilder.lte(value);
+            }
+        });
+        return rangeQueryBuilder;
+    }
+}

--- a/src/main/java/io/mewil/sturgeon/schema/util/NameNormalizer.java
+++ b/src/main/java/io/mewil/sturgeon/schema/util/NameNormalizer.java
@@ -28,12 +28,10 @@ public final class NameNormalizer {
   }
 
   private static String normalizeName(final String name) {
-    return name
-        .replaceAll("(^[0-9])", "_$1")
+    return name.replaceAll("(^[0-9])", "_$1")
+        .replaceAll("[()?@#]", "")
         .replace(" ", "_")
         .replace("+", "plus_")
-        .replace("-", "minus_")
-        .replace("@", "")
-        .replace("#", "");
+        .replace("-", "minus_");
   }
 }


### PR DESCRIPTION
Allow aggregation queries to accept boolean query arguments, which right now only includes range queries.
This commit also fixes cases for the sequence `(?)` in the NameNormalizer.
It also converts infinity values returned from aggregations to `null`.
Lastly, it adds support for should, must and must not queries to the Elasticsearch query builder. Previously all 4 queries were included in the schema, but only filter actually worked correctly. Now all 4 work as expected.